### PR TITLE
Fix how the Python interface passes float coefficients to C code.

### DIFF
--- a/examples/python/mpsolve.py
+++ b/examples/python/mpsolve.py
@@ -134,7 +134,10 @@ class MonomialPoly(Polynomial):
             _mps.mps_monomial_poly_set_coefficient_int(self._ctx._c_ctx, 
                                                          mp, n, coeff, 0)
         elif isinstance(coeff, float):
-            _mps.mps_monomial_poly_set_coefficient_d(self._ctx._c_ctx, mp, n, coeff, 0)
+            _mps.mps_monomial_poly_set_coefficient_d(
+                self._ctx._c_ctx, mp, n,
+                ctypes.c_double(coeff),
+                ctypes.c_double(0))
         elif isinstance(coeff, str):
             _mps.mps_monomial_poly_set_coefficient_s(self._ctx._c_ctx, mp, n, coeff, None);
         else:

--- a/examples/python/tests/simple_polynomial.py
+++ b/examples/python/tests/simple_polynomial.py
@@ -30,6 +30,30 @@ def simple_polynomial_example():
 
     print("")
 
+def simple_polynomial_int_coefficients():
+    n = 2
+    ctx = mpsolve.Context()
+    poly = mpsolve.MonomialPoly(ctx, n)
+
+    poly.set_coefficient (0, -1)
+    poly.set_coefficient (1, 0)
+    poly.set_coefficient (2, 2)
+    ctx.solve (poly)
+
+    print("")
+
+def simple_polynomial_float_coefficients():
+    n = 3
+    ctx = mpsolve.Context()
+    poly = mpsolve.MonomialPoly(ctx, n)
+
+    poly.set_coefficient (0, -1.0)
+    poly.set_coefficient (1, 0.0)
+    poly.set_coefficient (2, 2.5)
+    ctx.solve (poly)
+
+    print("")
+
 def simple_chebyshev_example():
     """Here is a simple example of a polynomial expressed in the
     Chebyshev basis."""
@@ -47,4 +71,6 @@ def simple_chebyshev_example():
 if __name__ == "__main__":
 
     simple_polynomial_example()
+    simple_polynomial_int_coefficients()
+    simple_polynomial_float_coefficients()
     simple_chebyshev_example()


### PR DESCRIPTION
A functionally equivalent fix appears in PR #4. That PR is a bit broader in scope though, so I propose this smaller one in case you prefer that. Feel free to merge either.

Also, this PR contains added test code that reproduces the problem for versions prior to this patch.