### PR TITLE
Canonicalize coefficients of monomials created from strings.

### DIFF
--- a/src/libmps/formal/formal-monomial.cpp
+++ b/src/libmps/formal/formal-monomial.cpp
@@ -93,6 +93,8 @@ Monomial::Monomial(const char * coeff_string, long degree)
   mCoeffR = er;
   mDegree = degree;
   free (er);
+
+  mCoeffR.canonicalize();
 }
 
 Monomial::Monomial(const char * real_part, const char * imag_part, long degree)
@@ -107,6 +109,9 @@ Monomial::Monomial(const char * real_part, const char * imag_part, long degree)
 
   free (er);
   free (ei);
+
+  mCoeffR.canonicalize();
+  mCoeffI.canonicalize();
 }
 
 Monomial::Monomial(const mpq_class coeff, long degree)


### PR DESCRIPTION
I am looking at adding mpsolve to the Fedora Linux package collection, so that Macaulay2 can use it.  I am using the 3.1.8 tarball from your website, since there doesn't appear to be one on github.  On my first build attempt, using an x86_64 Fedora Rawhide machine, "make check" showed one failed test, check_formal.  The relevant contents of test-suite.log are:
```
FAIL: check_formal
==================

Running suite(s): Formal arithmetic
2x + 1
33%: Checks: 3, Failures: 2, Errors: 0
check_formal.cpp:14:F:Monomial operations:monomial_creation:0: Monomial("1.01e2",12) != 101x^12
check_formal.cpp:24:F:Monomial operations:monomial_floating:0: Monomial("0.25") != 0.25
FAIL check_formal (exit status: 1)
```
For the failure at line 14, gdb shows that the result of `exp1.coefficientReal()` is an `mpq_t` representing 10100/100.  If canonicalized, that would of course equal 101.  With this commit, the test passes.