### PR TITLE
Fix typos in documentation; need asterisks for multiplication.

### DIFF
--- a/src/mpsolve/mpsolve.1.in
+++ b/src/mpsolve/mpsolve.1.in
@@ -124,7 +124,7 @@ Example: \fB\-dfi\fR for function calls and improvement
 \fB\-p poly\fR
 Solve the polynomial specified on the command line.
 .IP
-For example: mpsolve \fB-p\fR "x^4-6x^9+6/7x + 5"
+For example: mpsolve \fB-p\fR "x^4-6*x^9+6/7*x + 5"
 .TP
 \fB\-r\fR
 Use a recursive strategy to dispose the initial approximations.

--- a/src/mpsolve/mpsolve.c
+++ b/src/mpsolve/mpsolve.c
@@ -179,7 +179,7 @@ usage (mps_context * s, const char *program)
            "               Example: -dfi for function calls and improvement\n"
 #endif
 	   " -p poly     Solve the polynomial specified on the command line. \n"
-           "               Example: %s -p \"x^4-6x^9+6/7x + 5\" \n"
+           "               Example: %s -p \"x^4-6*x^9+6/7*x + 5\" \n"
 	   " -r          Use a recursive strategy to dispose the initial approximations.\n"
 	   "             This option is available only for monomial polynomials. \n"
 	   "             Note: this option is considered experimental.\n"

--- a/src/xmpsolve/mainwindow.ui
+++ b/src/xmpsolve/mainwindow.ui
@@ -49,7 +49,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Insert polynomial here:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt;Note:&lt;/span&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt; use 'x' as indeterminate, &lt;br/&gt;and (a +yi) for complex numbers.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Example: -2x + (1 + 3/2i)*x^2 +1.6e2&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Insert polynomial here:&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:8pt; font-weight:600;&quot;&gt;Note:&lt;/span&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt; use 'x' as indeterminate, &lt;br/&gt;and (a +yi) for complex numbers.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Example: -2*x + (1 + 3/2i)*x^2 +1.6e2&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>


### PR DESCRIPTION
Otherwise, we get an error:

    $ mpsolve -p "x^4-6x^9+6/7x + 5"
    ! MPSolve encountered an error: syntax error