### PR TITLE
Updates for octave 6.x.

### DIFF
--- a/examples/octave/mps_regenerate.cc
+++ b/examples/octave/mps_regenerate.cc
@@ -27,7 +27,7 @@ This function will take that b_i chosen as nodes and return the respective a_i s
 
   ComplexColumnVector b = args(0).complex_column_vector_value();
   int degree = nargin - 2;
-  ComplexColumnVector a(b.length());
+  ComplexColumnVector a(b.numel());
 
   cplx_t * fa = (cplx_t*) a.fortran_vec();
   cplx_t * fb = (cplx_t*) b.fortran_vec();
@@ -41,7 +41,7 @@ This function will take that b_i chosen as nodes and return the respective a_i s
       ComplexMatrix A = args(1).complex_matrix_value().transpose();
       cplx_t * A_data = (cplx_t*) A.fortran_vec();
       
-      for (int i = 0; i < a.length(); i++)
+      for (int i = 0; i < a.numel(); i++)
 	{
 	  long int exponent = 0;
 	  cplx_t prod;
@@ -49,7 +49,7 @@ This function will take that b_i chosen as nodes and return the respective a_i s
 	  mps_fhessenberg_shifted_determinant (ctx, A_data, fb[i], A.rows(), fa[i], &exponent);
 	  cplx_set (prod, cplx_one);
 
-	  for (int j = 0; j < b.length(); j++)
+	  for (int j = 0; j < b.numel(); j++)
 	    {
 	      if (i == j)
 		continue;

--- a/examples/octave/mps_roots.cc
+++ b/examples/octave/mps_roots.cc
@@ -93,7 +93,7 @@ fields: \n\n\
 
       /* If the string conversion triggers an error try to recover
        * a struct. */
-      if (args(1).is_map())
+      if (args(1).isstruct())
 	smap = args(1).map_value();
       else
 	{
@@ -179,7 +179,7 @@ fields: \n\n\
 	poly->fstart = _custom_start_function;
 	poly->dstart = _custom_dpe_start_function;
 
-	if (starting_points.length() != n -1)
+	if (starting_points.numel() != n -1)
 	  {
 	    octave_stdout << "Warning: The length of the starting points should be equal to the degree" << std::endl;
 	    return retval;

--- a/examples/octave/mps_secular.cc
+++ b/examples/octave/mps_secular.cc
@@ -56,7 +56,7 @@ values are 's' for secsolve and 'u' for unisolve.\n\
   ComplexColumnVector a = args(0).complex_column_vector_value();
   ComplexColumnVector b = args(1).complex_column_vector_value();
 
-  int n = a.length();
+  int n = a.numel();
 
   mps_context * ctx = mps_context_new();
   mps_secular_equation * sec = mps_secular_equation_new (ctx, (cplx_t*) a.fortran_vec(),


### PR DESCRIPTION
Three examples call octave functions that were deprecated in 5.x and have been removed entirely in 6.x.