### PR TITLE
Add missing includes for configure tests

### DIFF
--- a/m4/ax_func_snprintf.m4
+++ b/m4/ax_func_snprintf.m4
@@ -33,6 +33,8 @@ AC_MSG_CHECKING(for working snprintf)
 AC_CACHE_VAL(ac_cv_have_working_snprintf,
 [AC_TRY_RUN(
 [#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 int main(void)
 {
@@ -53,6 +55,8 @@ AC_CACHE_VAL(ac_cv_have_working_vsnprintf,
 [AC_TRY_RUN(
 [#include <stdio.h>
 #include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
 
 int my_vsnprintf (char *buf, const char *tmpl, ...)
 {


### PR DESCRIPTION
The GCC developers are considering dropping some backwards compatibility features of the compiler.  In particular, the changes will make GCC less forgiving about missing function prototypes.  The Fedora project is trying to get ahead of this change by doing test builds of packages with the GCC change in place.  See [this page](https://fedoraproject.org/wiki/Changes/PortingToModernC) for more information.

The MPSolve project has two configure tests with missing function prototypes.  Both call strcmp (which needs string.h) and exit (which needs stdlib.h).  This commit adds the missing #include statements.
