### PR TITLE
Fix #41 libpms API is missing some features available via command-line 

### DIFF
--- a/include/mps/context.h
+++ b/include/mps/context.h
@@ -583,6 +583,7 @@ void mps_context_set_output_goal (mps_context * s, mps_output_goal goal);
 void mps_context_set_search_set (mps_context * s, mps_search_set set);
 void mps_context_set_starting_phase (mps_context * s, mps_phase phase);
 void mps_context_set_log_stream (mps_context * s, FILE * logstr);
+void mps_context_set_root_stream (mps_context * s, FILE * rtstr);
 void mps_context_set_jacobi_iterations (mps_context * s, mps_boolean jacobi_iterations);
 void mps_context_select_starting_strategy (mps_context * s, mps_starting_strategy strategy);
 void mps_context_set_avoid_multiprecision (mps_context * s, mps_boolean avoid_multiprecision);

--- a/include/mps/context.h
+++ b/include/mps/context.h
@@ -583,6 +583,7 @@ void mps_context_select_starting_strategy (mps_context * s, mps_starting_strateg
 void mps_context_set_avoid_multiprecision (mps_context * s, mps_boolean avoid_multiprecision);
 void mps_context_set_crude_approximation_mode (mps_context * s, mps_boolean crude_approximation_mode);
 void mps_context_set_regeneration_driver (mps_context * s, mps_regeneration_driver * rd);
+void mps_context_set_n_threads (mps_context * s, int n_threads);
 
 /* Debugging */
 void mps_context_set_debug_level (mps_context * s, mps_debug_level level);

--- a/include/mps/context.h
+++ b/include/mps/context.h
@@ -48,6 +48,11 @@ typedef void* (*mps_callback)(mps_context * status, void * user_data);
 #define MPS_DSTART_PTR(x) (mps_dstart_ptr) & (x)
 #define MPS_MPSOLVE_PTR(x) (mps_mpsolve_ptr) & (x)
 
+/* Properties of the root */
+#define MPS_OUTPUT_PROPERTY_NONE      (0x00)
+#define MPS_OUTPUT_PROPERTY_REAL      (0x01)
+#define MPS_OUTPUT_PROPERTY_IMAGINARY (0x01 << 1)
+
 #ifdef _MPS_PRIVATE
 /**
  * @brief this struct holds the state of the mps computation
@@ -584,6 +589,7 @@ void mps_context_set_avoid_multiprecision (mps_context * s, mps_boolean avoid_mu
 void mps_context_set_crude_approximation_mode (mps_context * s, mps_boolean crude_approximation_mode);
 void mps_context_set_regeneration_driver (mps_context * s, mps_regeneration_driver * rd);
 void mps_context_set_n_threads (mps_context * s, int n_threads);
+void mps_context_set_root_properties (mps_context * s, char root_properties);
 
 /* Debugging */
 void mps_context_set_debug_level (mps_context * s, mps_debug_level level);

--- a/include/mps/context.h
+++ b/include/mps/context.h
@@ -575,6 +575,7 @@ void mps_context_set_input_prec (mps_context * s, long int prec);
 void mps_context_set_output_prec (mps_context * s, long int prec);
 void mps_context_set_output_format (mps_context * s, mps_output_format format);
 void mps_context_set_output_goal (mps_context * s, mps_output_goal goal);
+void mps_context_set_search_set (mps_context * s, mps_search_set set);
 void mps_context_set_starting_phase (mps_context * s, mps_phase phase);
 void mps_context_set_log_stream (mps_context * s, FILE * logstr);
 void mps_context_set_jacobi_iterations (mps_context * s, mps_boolean jacobi_iterations);

--- a/include/mps/private/options.h
+++ b/include/mps/private/options.h
@@ -159,11 +159,6 @@ struct mps_input_configuration {
   mps_phase starting_phase;
 };
 
-/* Properties of the root */
-#define MPS_OUTPUT_PROPERTY_NONE      (0x00)
-#define MPS_OUTPUT_PROPERTY_REAL      (0x01)
-#define MPS_OUTPUT_PROPERTY_IMAGINARY (0x01 << 1)
-
 /**
  * @brief Configuration for the output.
  *

--- a/src/libmps/common/context.c
+++ b/src/libmps/common/context.c
@@ -887,3 +887,18 @@ void mps_context_set_n_threads (mps_context *s, int n_threads)
 {
   s->n_threads = n_threads;
 }
+
+/**
+* @brief Define which properties of the roots must be determined by MPSolve.
+ *
+ * @param s The context where the change will have effect.
+ * @param root_properties Possible values:
+ *  -# MPS_OUTPUT_PROPERTY_NONE
+ *  -# MPS_OUTPUT_PROPERTY_REAL
+ *  -# MPS_OUTPUT_PROPERTY_IMAGINARY
+ *  -# MPS_OUTPUT_PROPERTY_REAL | MPS_OUTPUT_PROPERTY_IMAGINARY
+ */
+void mps_context_set_root_properties (mps_context *s, char root_properties)
+{
+  s->output_config->root_properties = root_properties;
+}

--- a/src/libmps/common/context.c
+++ b/src/libmps/common/context.c
@@ -876,3 +876,14 @@ mps_context_set_regeneration_driver (mps_context * s, mps_regeneration_driver * 
 {
   s->regeneration_driver = rd;
 }
+
+/**
+ * @brief Set the number of threads.
+ *
+ * @param s The context where the change will have effect.
+ * @param n_threads The number of thread to be spawned.
+ */
+void mps_context_set_n_threads (mps_context *s, int n_threads)
+{
+  s->n_threads = n_threads;
+}

--- a/src/libmps/common/context.c
+++ b/src/libmps/common/context.c
@@ -733,6 +733,19 @@ mps_context_set_log_stream (mps_context * s, FILE * logstr)
 }
 
 /**
+ * @brief Set root stream.
+ *
+ * @param s The <code>mps_context</code> of the current computation.
+ * @param rtstr The stream used to resume an interrupted computation
+ * or to load the approximations from a custom file.
+ */
+void
+mps_context_set_root_stream (mps_context * s, FILE * rtstr)
+{
+  s->rtstr = rtstr;
+}
+
+/**
  * @brief Set the phase from which the computation should start.
  *
  * @param s The <code>mps_context</code> of the current computation.

--- a/src/libmps/common/context.c
+++ b/src/libmps/common/context.c
@@ -637,6 +637,18 @@ mps_context_set_output_goal (mps_context * s, mps_output_goal goal)
 }
 
 /**
+ * @brief Restrict the search set for the roots.
+ *
+ * @param s The <code>mps_context</code> of the computation.
+ * @param set The search set for the roots.
+ */
+void
+mps_context_set_search_set(mps_context *s, mps_search_set set)
+{
+  s->output_config->search_set = set;
+}
+
+/**
  * @brief Set the value of the jacobi iterations switch in the MPSolve context.
  *
  * If jacobi_iterations is true then the Ehrlich-Aberth iterations will be carried

--- a/src/mpsolve/mpsolve.c
+++ b/src/mpsolve/mpsolve.c
@@ -603,7 +603,7 @@ main (int argc, char **argv)
 
         case 'j':
           mps_thread_pool_set_concurrency_limit (s, NULL, atoi (opt->optvalue));
-          s->n_threads = atoi (opt->optvalue);
+          mps_context_set_n_threads (s, atoi (opt->optvalue));
           break;
         default:
           usage (s, argv[0]);

--- a/src/mpsolve/mpsolve.c
+++ b/src/mpsolve/mpsolve.c
@@ -352,34 +352,34 @@ main (int argc, char **argv)
             switch (*opt->optvalue)
               {
               case 'a':
-                s->output_config->search_set = MPS_SEARCH_SET_COMPLEX_PLANE;
+                mps_context_set_search_set (s, MPS_SEARCH_SET_COMPLEX_PLANE);
                 break;
               case 'r':
-                s->output_config->search_set = MPS_SEARCH_SET_POSITIVE_REAL_PART;
+                mps_context_set_search_set (s, MPS_SEARCH_SET_POSITIVE_REAL_PART);
                 break;
               case 'l':
-                s->output_config->search_set = MPS_SEARCH_SET_NEGATIVE_REAL_PART;
+                mps_context_set_search_set (s, MPS_SEARCH_SET_NEGATIVE_REAL_PART);
                 break;
               case 'u':
-                s->output_config->search_set = MPS_SEARCH_SET_POSITIVE_IMAG_PART;
+                mps_context_set_search_set (s, MPS_SEARCH_SET_POSITIVE_IMAG_PART);
                 break;
               case 'd':
-                s->output_config->search_set = MPS_SEARCH_SET_NEGATIVE_IMAG_PART;
+                mps_context_set_search_set (s, MPS_SEARCH_SET_NEGATIVE_IMAG_PART);
                 break;
               case 'i':
-                s->output_config->search_set = MPS_SEARCH_SET_UNITARY_DISC;
+                mps_context_set_search_set (s, MPS_SEARCH_SET_UNITARY_DISC);
                 break;
               case 'o':
-                s->output_config->search_set = MPS_SEARCH_SET_UNITARY_DISC_COMPL;
+                mps_context_set_search_set (s, MPS_SEARCH_SET_UNITARY_DISC_COMPL);
                 break;
               case 'R':
-                s->output_config->search_set = MPS_SEARCH_SET_REAL;
+                mps_context_set_search_set (s, MPS_SEARCH_SET_REAL);
                 break;
               case 'I':
-                s->output_config->search_set = MPS_SEARCH_SET_IMAG;
+                mps_context_set_search_set (s, MPS_SEARCH_SET_IMAG);
                 break;
               case 'U':
-                s->output_config->search_set = MPS_SEARCH_SET_CUSTOM;
+                mps_context_set_search_set (s, MPS_SEARCH_SET_CUSTOM);
                 break;
               default:
                 mps_error (s, "Bad search set switch: ", opt->optvalue,

--- a/src/mpsolve/mpsolve.c
+++ b/src/mpsolve/mpsolve.c
@@ -433,7 +433,7 @@ main (int argc, char **argv)
 
             /* I/O streams */
           case 'R':
-            s->rtstr = fopen (opt->optvalue, "r");
+            mps_context_set_root_stream (s, fopen (opt->optvalue, "r"));
             if (s->rtstr == NULL)
               mps_error (s, "Cannot open roots file: ", opt->optvalue);
             s->resume = true;
@@ -573,7 +573,7 @@ main (int argc, char **argv)
 	    }
 	  else
 	    {
-	      s->rtstr = fopen (opt->optvalue, "r");
+	      mps_context_set_root_stream (s, fopen (opt->optvalue, "r"));
 	      if (! s->rtstr)
 		{
 		  mps_error (s, "Cannot open the given file: %s", opt->optvalue);

--- a/src/mpsolve/mpsolve.c
+++ b/src/mpsolve/mpsolve.c
@@ -412,17 +412,16 @@ main (int argc, char **argv)
             switch (*opt->optvalue)
               {
               case 'n':
-                s->output_config->root_properties = MPS_OUTPUT_PROPERTY_NONE;
+                mps_context_set_root_properties (s, MPS_OUTPUT_PROPERTY_NONE);
                 break;
               case 'r':
-                s->output_config->root_properties = MPS_OUTPUT_PROPERTY_REAL;
+                mps_context_set_root_properties (s, MPS_OUTPUT_PROPERTY_REAL);
                 break;
               case 'i':
-                s->output_config->root_properties = MPS_OUTPUT_PROPERTY_IMAGINARY;
+                mps_context_set_root_properties (s, MPS_OUTPUT_PROPERTY_IMAGINARY);
                 break;
               case 'b':
-                s->output_config->root_properties = MPS_OUTPUT_PROPERTY_REAL | 
-                  MPS_OUTPUT_PROPERTY_IMAGINARY;
+                mps_context_set_root_properties (s, MPS_OUTPUT_PROPERTY_REAL | MPS_OUTPUT_PROPERTY_IMAGINARY);
                 break;
               default:
                 mps_error (s, "Bad detection switch: ", opt->optvalue,


### PR DESCRIPTION
This PR fixes #41 by adding the following functions to `include/mps/context.h`:
```
// Set the number of threads, see "mpsolve -j" option
void mps_context_set_n_threads (mps_context * s, int n_threads);

// Restrict the search set for the roots, see "mpsolve -S" option
void mps_context_set_search_set (mps_context * s, mps_search_set set);

// Detect properties of the roots, see "mpsolve -D" option
void mps_context_set_root_properties (mps_context * s, char root_properties);

// Read the starting approximations from the given file, see "mpsolve -s" option
void mps_context_set_root_stream (mps_context * s, FILE * rtstr);
```