### PR TITLE
Don't define mps_boolean as enum in C23 (true/false are keywords)

### DIFF
--- a/include/mps/mps.h
+++ b/include/mps/mps.h
@@ -25,7 +25,7 @@
 #ifndef MPS_CORE_H_
 #define MPS_CORE_H_
 
-#ifdef __cplusplus
+#if defined(__cplusplus) || __STDC_VERSION__ >= 202311L
 #define __MPS_NOT_DEFINE_BOOL
 #endif
 


### PR DESCRIPTION
Fixes build in GCC-15, where C23 is the default. 

This fixes [Debian bug #1097416](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1097416).