### PR TITLE
Include cmath in C++ before defining isnan macro

### DIFF
--- a/include/mps/types.h
+++ b/include/mps/types.h
@@ -21,7 +21,11 @@ typedef bool mps_boolean;
 typedef int mps_debug_level;
 
 /* Handle systems where isnan and isinf are not available */
-#include <math.h>
+#ifdef __cplusplus
+  #include <cmath>
+#else
+  #include <math.h>
+#endif
 #ifndef isnan
           # define isnan(x) \
   (sizeof(x) == sizeof(long double) ? isnan_ld (x) \


### PR DESCRIPTION
Otherwise we get the following compile error in macOS:

    /Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/cmath:587:17: error: expected unqualified-id
        return std::isnan(__lcpp_x);
                    ^
    ../../include/mps/types.h:27:3: note: expanded from macro 'isnan'
      (sizeof(x) == sizeof(long double) ? isnan_ld (x) \
      ^