### PR TITLE
Use CPPFLAGS instead of CFLAGS for specifying header directories

### DIFF
--- a/src/mpsolve/Makefile.am
+++ b/src/mpsolve/Makefile.am
@@ -6,10 +6,12 @@ man_MANS = ${builddir}/mpsolve.1
 
 EXTRA_DIST = mpsolve.1
 
-mpsolve_CFLAGS = \
+mpsolve_CPPFLAGS = \
         -I${top_srcdir}/include \
 	-I. \
-	-I${top_builddir}/include \
+	-I${top_builddir}/include
+
+mpsolve_CFLAGS = \
 	$(GMP_CFLAGS) \
 	$(GTK_CFLAGS) \
 	$(PTHREAD_CFLAGS) \


### PR DESCRIPTION
CPPFLAGS appear before CFLAGS, so if the user passes some directories manually using CPPFLAGS, they will appear first.  This is a problem if these directories contain older versions of the mpsolve headers.  We want to ensure that the current versions are found first.